### PR TITLE
Add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.xml]
+indent_size = 4


### PR DESCRIPTION
Makes sure everybody has the same editor settings (indentation etc.), see [editorconfig.org](https://editorconfig.org/).

There's only the config.xml that uses 4 space indentation as far as I can see. Maybe we should make that 2 space indentation too, just so every file uses the same style.